### PR TITLE
Remove token and password from register response

### DIFF
--- a/CodeSphere.Application/Features/Authentication/Commands/Register/RegisterCommandHandler.cs
+++ b/CodeSphere.Application/Features/Authentication/Commands/Register/RegisterCommandHandler.cs
@@ -60,9 +60,7 @@ namespace CodeSphere.Application.Features.Authentication.Commands.Register
 
             var registerCommandHandler = new RegisterCommandResponse()
             {
-                Password = request.Password,
                 Email = request.Email,
-                Token = await _authService.CreateTokenAsync(mappedUser, _userManager)
             };
 
             return await Response.SuccessAsync(registerCommandHandler, "Registered Successfully", System.Net.HttpStatusCode.Created);

--- a/CodeSphere.Application/Features/Authentication/Commands/Register/RegisterCommandResponse.cs
+++ b/CodeSphere.Application/Features/Authentication/Commands/Register/RegisterCommandResponse.cs
@@ -8,8 +8,6 @@ namespace CodeSphere.Application.Features.Authentication.Commands.Register
 {
 	public class RegisterCommandResponse
 	{
-        public string Password { get; set; }
         public string Email { get; set; }
-        public string Token { get; set; }
     }
 }

--- a/CodeSphere.Application/Features/Contest/Queries/GetContestStanding/GetContestStandingQuery.cs
+++ b/CodeSphere.Application/Features/Contest/Queries/GetContestStanding/GetContestStandingQuery.cs
@@ -34,12 +34,12 @@ namespace CodeSphere.Application.Features.Contest.Queries.GetContestStanding
             if (contest == null)
                 return await Response.FailureAsync("Contest Not Found", System.Net.HttpStatusCode.NotFound);
 
-            if (contest.ContestStatus == ContestStatus.Running)
-            {
-                // return the data from cache
-                var leaderboard = cacheService.GetContestStanding(request.ContestId, request.Start, request.Stop);
-                return await Response.SuccessAsync(leaderboard, "Contest Standing Fetched Successfully", System.Net.HttpStatusCode.OK);
-            }
+            //if (contest.ContestStatus == ContestStatus.Running)
+            //{
+            //    // return the data from cache
+            //    var leaderboard = cacheService.GetContestStanding(request.ContestId, request.Start, request.Stop);
+            //    return await Response.SuccessAsync(leaderboard, "Contest Standing Fetched Successfully", System.Net.HttpStatusCode.OK);
+            //}
 
             var standing = await unitOfWork.ContestRepository.GetContestStanding(request.ContestId, 0, 10);
             return await Response.SuccessAsync(standing, "Contest Standing Fetched Successfully", System.Net.HttpStatusCode.OK);

--- a/CodeSphere.WebApi/Hubs/VideoChatHub.cs
+++ b/CodeSphere.WebApi/Hubs/VideoChatHub.cs
@@ -1,4 +1,5 @@
 ﻿using CodeSphere.Domain.Models.Identity;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.SignalR;
 using System.Collections.Concurrent;

--- a/CodeSphere.WebApi/appsettings.json
+++ b/CodeSphere.WebApi/appsettings.json
@@ -8,8 +8,8 @@
   "AllowedHosts": "*",
   "ConnectionStrings": {
     "DefaultConnection": "server=.;database=CodeSphere;trusted_connection=true;TrustServerCertificate=True;",
-    //"Redis": "127.0.0.1:6379,abortConnect=false,connectRetry=5,connectTimeout=10000"
-    "Redis": "codesphere.cache:6379,abortConnect=false"
+    "Redis": "127.0.0.1:6379,abortConnect=false,connectRetry=5,connectTimeout=10000"
+    //"Redis": "codesphere.cache:6379,abortConnect=false"
   },
   "JWT": {
     "Key": "",


### PR DESCRIPTION
### Summary
Removed the `token` and `password` fields from the register response.

### Why?
Previously, the token was returned immediately after registration, which allowed users to:

- Register with a fake or unverified email.
- Extract the token from the response.
- Use it to access protected routes without confirming their email.

This effectively bypassed the email verification step.

Additionally, `password` (even if hashed) should never be included in any API response for security best practices.

### Fix
- Removed token and password from the register response.
- Users now must confirm their email before they can log in or make authorized requests.